### PR TITLE
Edit readme - playbook must be run from CM server

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ An Ansible Playbook that installs the Cloudera stack on RHEL/CentOS
 
 # Running the playbook
 
-* Setup an [Ansible Control Machine](http://docs.ansible.com/ansible/intro_installation.html) 
+On the host that you will designate as the Cloudera Manager sever:
+
+* Setup an [Ansible Control Machine](http://docs.ansible.com/ansible/intro_installation.html)
+* Clone this Git repository
 * Create Ansible configuration (optional):
 
 ```ini
@@ -61,6 +64,8 @@ master_servers
 worker_servers
 ```
     
+Note that the host you specify under [scm_server] must be the same host from which you are running the playbook.
+	
 * Run playbook
  
 ```shell


### PR DESCRIPTION
Playbook must be run from the host designated as the CM server, else the user will run into issues with cm-api not being installed in the right place. Amended readme to add this info and to make clear that all steps must be taken from that same host.