### PR TITLE
Use the template plugin and avoid the need for local sudo

### DIFF
--- a/roles/cdh/tasks/main.yml
+++ b/roles/cdh/tasks/main.yml
@@ -21,12 +21,9 @@
 - debug: msg="Cluster '{{ cluster_display_name }}' exists - {{ cluster_exists }}"
 
 # https://www.cloudera.com/documentation/enterprise/latest/topics/install_cluster_template.html
-- name: Prepare cluster template
-  template:
-    src: "base.j2"
-    dest: "{{ tmp_dir }}/cluster.json"
+- set_fact:
+    cluster_template_json: "{{ lookup('template', 'base.j2', convert_data=False) }}"
   when: cluster_exists == False
-  delegate_to: localhost
 
 # https://cloudera.github.io/cm_api/apidocs/v13/path__cm_importClusterTemplate.html
 - name: Import cluster template
@@ -34,7 +31,7 @@
     url: "{{ cm_api_url }}/cm/importClusterTemplate?addRepositories=true"
     method: POST
     body_format: json
-    body: "{{ lookup('file', ''+ tmp_dir + '/cluster.json') }}"
+    body: "{{ cluster_template_json|to_json }}"
     status_code: 200
     force_basic_auth: yes
     user: "{{ scm_default_user }}"
@@ -42,7 +39,6 @@
     return_content: yes
   register: template_resp
   when: cluster_exists == False
-  delegate_to: localhost
 
 - debug: var=template_resp
   when: cluster_exists == False
@@ -55,8 +51,3 @@
 
 - debug: msg="Login to Cloudera Manager to monitor import progress - http://{{ hostvars[scm_hostname]['inventory_hostname'] }}:{{ scm_port }}/cmf/commands/commands"
   when: cluster_exists == False
-
-- file:
-    path: "{{ tmp_dir }}/cluster.json"
-    state: absent
-  delegate_to: localhost

--- a/roles/cdh/tasks/main.yml
+++ b/roles/cdh/tasks/main.yml
@@ -40,7 +40,9 @@
   register: template_resp
   when: cluster_exists == False
 
-- debug: var=template_resp
+- debug: 
+    var: template_resp
+    verbosity: 1
   when: cluster_exists == False
 
 - set_fact: command_id="{{ template_resp.json.id }}"

--- a/roles/scm/tasks/cms.yml
+++ b/roles/scm/tasks/cms.yml
@@ -3,7 +3,8 @@
 # Wait for agents to send heartbeats in case SCM has just been restarted
 # Adding CMS will fail if host details haven't been reported in
 - name: Wait for agent heartbeats
-  pause: seconds=30
+  pause:
+    seconds: 30
 
 # Prepare CMS template
 - name: Prepare CMS template
@@ -30,7 +31,9 @@
     - "'CMS instance already exists' not in cms_resp.content"
   delegate_to: localhost
 
-- debug: var=cms_resp
+- debug: 
+    var: cms_resp
+    verbosity: 1
 
 # https://cloudera.github.io/cm_api/apidocs/v12/path__cm_service_commands_start.html
 - name: Start Cloudera Management Services (CMS)
@@ -45,9 +48,6 @@
   register: start_resp
   failed_when: "'startTime' not in start_resp.content"
 
-- debug: var=start_resp
-
-- file:
-    path: "{{ tmp_dir }}/cms_base.json"
-    state: absent
-  delegate_to: localhost
+- debug: 
+    var: start_resp
+    verbosity: 1

--- a/roles/scm/tasks/scm.yml
+++ b/roles/scm/tasks/scm.yml
@@ -1,10 +1,6 @@
 ---
-
-- name: Prepare Cloudera Manager settings
-  template:
-    src: "scm.j2"
-    dest: "{{ tmp_dir }}/scm.json"
-  delegate_to: localhost
+- set_fact:
+    scm_config_json: "{{ lookup('template', 'scm.j2', convert_data=False) }}"
 
 # https://cloudera.github.io/cm_api/apidocs/v13/path__cm_config.html
 - name: Update Cloudera Manager settings
@@ -12,20 +8,17 @@
     url: "{{ cm_api_url }}/cm/config"
     method: PUT
     body_format: json
-    body: "{{ lookup('file', ''+ tmp_dir + '/scm.json') }}"
+    body: "{{ scm_config_json|to_json }}"
     status_code: 200
     force_basic_auth: yes
     user: "{{ scm_default_user }}"
     password: "{{ scm_default_pass }}"
     return_content: yes
   register: scm_resp
-  delegate_to: localhost
-- debug: var=scm_resp
 
-- file:
-    path: "{{ tmp_dir }}/scm.json"
-    state: absent
-  delegate_to: localhost
+- debug: 
+    var: scm_resp
+    verbosity: 1
 
 # https://cloudera.github.io/cm_api/apidocs/v13/path__cm_commands_importAdminCredentials.html
 - name: Import KDC admin credentials


### PR DESCRIPTION
This PR, heavily tested, brings multiple advantages
* Avoid having to use a tmp file to resolve the template
  * this should also have avoided issue https://github.com/cloudera/cloudera-playbook/issues/20
* No need to run a task locally (thus no more `delegate_to` tasks .. run with with become/sudo)
  * this allows running the deployment from a non root (resp sudo) shell, as is usually the case when running from your personal pc/mac
* less code :)

Thanks for considering @roczei 