### PR TITLE
added new variables that allow to disable the installation of some parts …

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -52,6 +52,15 @@ cluster_version_cdh_minor: "{{ cluster_version_cdh.split('.')[1] }}"
 cluster_version_cm_major: "{{ cluster_version_cm.split('.')[0] }}"
 cluster_version_cm_minor: "{{ cluster_version_cm.split('.')[1] }}"
 
+# Helper variables to control parts of the playbook
+cluster_install_java: true
+cluster_install_krb5_server: true
+cluster_install_mysql: true
+cluster_install_rngd: true
+cluster_install_groups_users: true
+cluster_install_cdh: true
+
+
 cloudera_archive: https://archive.cloudera.com
 
 configs_by_version:

--- a/roles/cm_agents/tasks/main.yml
+++ b/roles/cm_agents/tasks/main.yml
@@ -2,6 +2,7 @@
 
 - name: Apply temporary workaround for Cloudera Manager issue OPSAPS-36322
   include: 36322.yml
+  when: cluster_install_groups_users | default(false)
 
 - name: Install Cloudera Manager Agents
   yum:

--- a/site.yml
+++ b/site.yml
@@ -4,25 +4,28 @@
 - name: Configure Cloudera Manager Repository
   hosts: cdh_servers
   roles:
-    - cm_repo
+    - role: cm_repo
   tags: cm_repo
 
 - name: Install rngd
   hosts: cdh_servers
   roles:
-    - rngd
+    - role: rngd
+      when: cluster_install_rngd
   tags: rngd
 
 - name: Install Java
   hosts: cdh_servers
   roles:
-    - java
+    - role: java
+      when: cluster_install_java 
   tags: java
 
 - name: Install MariaDB and create databases
   hosts: db_server
   roles:
-    - mariadb
+    - role: mariadb
+      when: cluster_install_mysql
   tags:
     - mysql
     - mysql_server
@@ -30,7 +33,8 @@
 - name: Install MySQL Connector
   hosts: cdh_servers
   roles:
-    - mysql_connector
+    - role: mysql_connector
+      when: cluster_install_mysql
   tags:
     - mysql
     - mysql_client
@@ -38,36 +42,42 @@
 - name: Install MIT KDC Server
   hosts: krb5_server
   roles:
-    - krb5/server
+    - role: krb5/server
+      when: cluster_install_krb5_server
   tags: krb5
 
 - name: Install MIT KDC Client
   hosts: all
   roles:
-    - { role: krb5/client, when: (krb5_kdc_type is defined) and (krb5_kdc_type != 'none') }
+    - role: krb5/client
+      when: (krb5_kdc_type is defined) and (krb5_kdc_type != 'none')
   tags: krb5
 
 - name: Configure EPEL Repository
   hosts: scm_server
   roles:
-    - epel
+    - role: epel
   tags: epel
 
 - name: Install Cloudera Manager Agents
   hosts: cdh_servers
   roles:
-    - cm_agents
+    - role: cm_agents
   tags: cm_agents
 
 - name: Install Cloudera Manager Server
   hosts: scm_server
   roles:
-    - scm
-  tags: cluster_template
+    - role: scm
+  tags: 
+    - cm_server
+    - cluster_template
 
 - name: Install CDH
   hosts: scm_server
   roles:
+    - role: cdh
+      when: cluster_install_cdh
+  tags: 
     - cdh
-  tags: cluster_template
-
+    - cluster_template


### PR DESCRIPTION
…(like java, rngd, mysql)

Motivation:
* Allow to switch of the deployment parts we want to handle outside this playbook, in a more customized way
* disable Java installation: the included OracleJDK-7 deployment is outdated, and most people that deploy a new cluster are much better off with a JDK-8 (even openjdk8 is perfectly fine), more infos: https://github.com/cloudera/cloudera-playbook/issues/24
* disable Mysql installation: Useful if you want to use postgresql instead
  * for this see also https://github.com/cloudera/cloudera-playbook/pull/30