### PR TITLE
added new variable database_type to switch between CDH supported databases…

### DIFF
--- a/group_vars/db_server.yml
+++ b/group_vars/db_server.yml
@@ -9,49 +9,52 @@ mysql_pid_dir: /var/run/mysqld
 mysql_pid_file: "{{ mysql_pid_dir }}/mysqld.pid"
 mysql_root_password: changeme
 
+# Supported database types: mysql,postgresql,...
+database_type: mysql
+
 databases:
   scm:
     name: 'scm'
     user: 'scm'
     pass: 'scm_password'
-    type: 'mysql'
+    type: '{{ database_type }}'
   amon:
     name: 'amon'
     user: 'amon'
     pass: 'amon_password'
-    type: 'mysql'
+    type: '{{ database_type }}'
   rman:
     name: 'rman'
     user: 'rman'
     pass: 'rman_password'
-    type: 'mysql'
+    type: '{{ database_type }}'
   nav:
     name: 'nav'
     user: 'nav'
     pass: 'nav_password'
-    type: 'mysql'
+    type: '{{ database_type }}'
   navms:
     name: 'navms'
     user: 'navms'
     pass: 'navms_password'
-    type: 'mysql'
+    type: '{{ database_type }}'
   metastore:
     name: 'metastore'
     user: 'hive'
     pass: 'hive_password'
-    type: 'mysql'
+    type: '{{ database_type }}'
   sentry:
     name: 'sentry'
     user: 'sentry'
     pass: 'sentry_password'
-    type: 'mysql'
+    type: '{{ database_type }}'
   hue:
     name: 'hue'
     user: 'hue'
     pass: 'hue_password'
-    type: 'mysql'
+    type: '{{ database_type }}'
   oozie:
     name: 'oozie'
     user: 'oozie'
     pass: 'oozie_password'
-    type: 'mysql'
+    type: '{{ database_type }}'

--- a/roles/scm/tasks/main.yml
+++ b/roles/scm/tasks/main.yml
@@ -13,7 +13,7 @@
   command: /usr/share/cmf/schema/scm_prepare_database.sh
              -f
              --host {{ hostvars[db_hostname]['inventory_hostname'] }}
-             mysql {{ databases.scm.name }} {{ databases.scm.user }} {{ databases.scm.pass }}
+             {{ database_type }} {{ databases.scm.name }} {{ databases.scm.user }} {{ databases.scm.pass }}
   changed_when: False
 
 - name: Start the Cloudera Manager Server


### PR DESCRIPTION
… (mysql, postgresql,...)

Important: 
* Only type `mysql` is (currently) supported by the playbook out of the box
* With type `postgresql` you have to ensure that the `db_server` runs a postgresql-server incl. the required logical databases
  * For this I've done playbooks for latest postgres 9.6.x on centos-7 , based on https://github.com/geerlingguy/ansible-role-postgresql/, that I could publish, in a separate PR, in this repo (on request)