### PR TITLE
remove hardcoded include_vars of group_vars…

### DIFF
--- a/roles/cdh/tasks/main.yml
+++ b/roles/cdh/tasks/main.yml
@@ -1,9 +1,5 @@
 ---
 
-- include_vars: ../../../group_vars/cdh_servers.yml
-- include_vars: ../../../group_vars/scm_server.yml
-- include_vars: ../../../group_vars/db_server.yml
-
 # Check whether cluster already exists
 # https://cloudera.github.io/cm_api/apidocs/v13/path__clusters.html
 - name: Check whether cluster exists

--- a/roles/scm/tasks/main.yml
+++ b/roles/scm/tasks/main.yml
@@ -1,7 +1,5 @@
 ---
 
-- include_vars: ../../../group_vars/db_server.yml
-
 - name: Install the Cloudera Manager Server Packages
   yum: name={{ item }} state=installed
   with_items:


### PR DESCRIPTION
… to avoid conflicts when using (inventory) group_vars

Of course only removing the include_vars tasks will break the playbook in the current state, unless following additional (highly) recommended changes are done (which I did not here, to avoid conflicts with open PRs!):
Reorganize the current `group_vars` folder by either
* (1) Simplest solution: creating a `group_vars/all` folder, and move all the current group_vars/*yml  files there (incl. the `all` file, I'ld also append '.yml' extension)
  * This makes all vars visible in the (special) `all` group (even for local/localhost tasks, which I got rid of in 1-2 other PRs)
  * This could btw fix some of the issues reported (where a dict/var could not be found)
  * One could remove most of the `hostvars[` usages (workarounds?) and directly reference the required variables
  * Extra Adv.: The playbook `group_vars/all` vars have lower precedence than inventory `group_vars/$group` (despite that in general playbook has *higher* precedence than inventory group_vars, which I think is sub-optimal, but another story!)
* (2) solution using less `all` scope: creating a `group_vars/cdh_servers` folder, and move all the files there, *except* the `all` file, which still might need `all` scope, for vars used in localhost tasks, because  `cdh_servers` group, despite containing all the configured servers, it will not contain 'localhost'  unless explicitly added)

Whatever the exact `group_vars`  refactoring choosen, the right strategy is to use the right `group_vars/$group` for each variable, so no need for any hardcoded include_vars which break the whole variable precedence