### PR TITLE
Molecule tests v0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+---
+sudo: required
+
+language: python
+
+services:
+  - docker
+
+install:
+  # molecule version >v2.22 required for compatibility with ansible >2.8
+  - pip install molecule==2.22
+  # Note: ansible 2.9.0 is buggy, see the README
+  #- pip install ansible==2.8.2
+  - pip install ansible==2.9.1
+  - pip install docker
+script:
+  - molecule test
+  # TODO test more scenarios (multi-node !?)
+  #- molecule test --scenario-name xxx
+
+notifications:
+  webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,8 @@ install:
   #- pip install ansible==2.8.2
   - pip install ansible==2.9.1
   - pip install docker
+  # 'jmespath' required by the 'cdh' role (that uses the 'json_query' filter)
+  - pip install jmespath
 script:
   - molecule test
   # TODO test more scenarios (multi-node !?)

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -1,0 +1,14 @@
+# Molecule managed
+
+{% if item.registry is defined %}
+FROM {{ item.registry.url }}/{{ item.image }}
+{% else %}
+FROM {{ item.image }}
+{% endif %}
+
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash iproute && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash iproute && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+    elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml iproute2 && zypper clean -a; \
+    elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
+    elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates iproute2 && xbps-remove -O; fi

--- a/molecule/default/INSTALL.rst
+++ b/molecule/default/INSTALL.rst
@@ -1,0 +1,22 @@
+*******
+Docker driver installation guide
+*******
+
+Requirements
+============
+
+* Docker Engine
+
+Install
+=======
+
+Please refer to the `Virtual environment`_ documentation for installation best
+practices. If not using a virtual environment, please consider passing the
+widely recommended `'--user' flag`_ when invoking ``pip``.
+
+.. _Virtual environment: https://virtualenv.pypa.io/en/latest/
+.. _'--user' flag: https://packaging.python.org/tutorials/installing-packages/#installing-to-the-user-site
+
+.. code-block:: bash
+
+    $ pip install 'molecule[docker]'

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,0 +1,18 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+lint:
+  name: yamllint
+platforms:
+  - name: instance
+    image: centos:7
+provisioner:
+  name: ansible
+  lint:
+    name: ansible-lint
+verifier:
+  name: testinfra
+  lint:
+    name: flake8

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -5,13 +5,77 @@ driver:
   name: docker
 lint:
   name: yamllint
+# Using geerlingguy's image that provides centos7 with ansible AND systemd
 platforms:
-  - name: instance
-    image: centos:7
+  - name: "${MOLECULE_DISTRO:-centos7}-cdh01.local"
+    image: "geerlingguy/docker-${MOLECULE_DISTRO:-centos7}-ansible:latest"
+    pre_build_image: True
+    privileged: True
+    volume_mounts:
+      - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
+    command: "/usr/sbin/init"
+    groups:
+      - cdh_master
+      - cdh
+      # following groups required by the role's site.yml playbook
+      - cdh_servers
+      - db_server
+      - scm_server # group used during 'scm' role
+      - master_servers # group used to install mysql-connector
+    # networks:
+    #   - name: molecule_cdh
+    # network_mode: bridge
+
 provisioner:
   name: ansible
+  config_options:
+    defaults:
+      gathering: smart
+      fact_caching: jsonfile
+      fact_caching_connection: /tmp/facts_cache
+    ssh_connection:
+      pipelining: True
+
+  options:
+    diff: true
+    v: True
+  inventory:
+    group_vars:
+      # Note: 'all' inventory group_vars will be overriden by the 'all' playbook group_vars, but not specific groups
+      cdh_servers:
+        # we install our own openjdk-8 (as the role only supports JDK7)
+        cdh_install_java: false
+        # for molecule tests it's enough to use the builtin Mysql
+        cdh_install_mysql: true
+        cdh_install_rngd: false
+        cdh_install_groups_users: false
+        cdh_install_cluster: false
+
+        # Ensure that the master node is the first in the list (not guaranteed in 'groups.kdcs')
+        kerberos_server_kdcs: "{{ groups.cdh_master }}"
+        kerberos_server_kadmin_host: "{{ groups.cdh_master[0] }}"
+        kerberos_server_realm_name: EXAMPLE.COM
+        kerberos_server_domain: "local"
+        # To make molecule tests work, need to disable keberos reverse DNS, because docker builtin DNS is inconsistent
+        # Details: Returned PTR were suffixed with the network name, except for the own host (resolved by /etc/hosts)
+        kerberos_server_rdns: "false"
+
   lint:
     name: ansible-lint
+scenario:
+  name: default
+  test_sequence:
+    # - lint
+    #- destroy
+    - dependency
+    - syntax
+    - create
+    - prepare
+    - converge
+    #- idempotence
+    # - side_effect
+    - verify
+    #- destroy
 verifier:
   name: testinfra
   lint:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -1,4 +1,10 @@
 ---
+# Molecule config for a single-node CDH cluster
+#
+# Notes:
+# - Linters are set enabled=false because the roles currently contains many lint warnings
+# - The 'destroy' action is commented out to avoid accidentally destroying your molecule cluster
+#
 dependency:
   name: galaxy
 driver:
@@ -15,24 +21,33 @@ platforms:
       - "/sys/fs/cgroup:/sys/fs/cgroup:rw"
     command: "/usr/sbin/init"
     groups:
-      - cdh_master
-      - cdh
       # following groups required by the role's site.yml playbook
       - cdh_servers
       - db_server
       - scm_server # group used during 'scm' role
-      - master_servers # group used to install mysql-connector
+      - krb5_server
     # networks:
     #   - name: molecule_cdh
     # network_mode: bridge
+    # Host networking did not work on my Macbook (it hang at task waiting for the Ambari Agents registration)
+    #network_mode: host
+    published_ports:
+      # Cloudera Manager
+      - 0.0.0.0:7180:7180/tcp
+      # YARN
+      - 0.0.0.0:8088:8088/tcp
+      # HDFS
+      - 0.0.0.0:50070:50070/tcp
+      - 0.0.0.0:50075:50075/tcp
 
 provisioner:
   name: ansible
   config_options:
-    defaults:
-      gathering: smart
-      fact_caching: jsonfile
-      fact_caching_connection: /tmp/facts_cache
+    #TODO enable later
+    # defaults:
+    #   gathering: smart
+    #   fact_caching: jsonfile
+    #   fact_caching_connection: /tmp/facts_cache
     ssh_connection:
       pipelining: True
 
@@ -43,23 +58,10 @@ provisioner:
     group_vars:
       # Note: 'all' inventory group_vars will be overriden by the 'all' playbook group_vars, but not specific groups
       cdh_servers:
-        # we install our own openjdk-8 (as the role only supports JDK7)
-        cdh_install_java: false
-        # for molecule tests it's enough to use the builtin Mysql
-        cdh_install_mysql: true
-        cdh_install_rngd: false
-        cdh_install_groups_users: false
-        cdh_install_cluster: false
-
-        # Ensure that the master node is the first in the list (not guaranteed in 'groups.kdcs')
-        kerberos_server_kdcs: "{{ groups.cdh_master }}"
-        kerberos_server_kadmin_host: "{{ groups.cdh_master[0] }}"
-        kerberos_server_realm_name: EXAMPLE.COM
-        kerberos_server_domain: "local"
-        # To make molecule tests work, need to disable keberos reverse DNS, because docker builtin DNS is inconsistent
-        # Details: Returned PTR were suffixed with the network name, except for the own host (resolved by /etc/hosts)
-        kerberos_server_rdns: "false"
-
+        java_installation_strategy: package
+        # assigning templates to our host:
+        host_template: HostTemplate-Edge
+        role_ref_names: HDFS-HTTPFS-1
   lint:
     name: ansible-lint
 scenario:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -2,11 +2,8 @@
 - name: Pre-reqs
   hosts: all
   tasks:
-    - name: openjdk8
-      package:
-        name: java-1.8.0-openjdk
-  #roles:
-  # - role: cloudera-playbook
+    - debug:
+        msg: "Pre-reqs tasks if needed"
 
 - name: Converge
   # Note: To override the repo's "playbook group_vars" it's easier to use a "vars:" block here, as inventory vars have lower precedence!

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -1,5 +1,13 @@
 ---
-- name: Converge
+- name: Pre-reqs
   hosts: all
-  roles:
-    - role: cloudera-playbook
+  tasks:
+    - name: openjdk8
+      package:
+        name: java-1.8.0-openjdk
+  #roles:
+  # - role: cloudera-playbook
+
+- name: Converge
+  # Note: To override the repo's "playbook group_vars" it's easier to use a "vars:" block here, as inventory vars have lower precedence!
+  import_playbook: ../../site.yml

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -1,0 +1,5 @@
+---
+- name: Converge
+  hosts: all
+  roles:
+    - role: cloudera-playbook

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -1,0 +1,14 @@
+import os
+
+import testinfra.utils.ansible_runner
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    os.environ['MOLECULE_INVENTORY_FILE']).get_hosts('all')
+
+
+def test_hosts_file(host):
+    f = host.file('/etc/hosts')
+
+    assert f.exists
+    assert f.user == 'root'
+    assert f.group == 'root'

--- a/roles/scm/tasks/cms.yml
+++ b/roles/scm/tasks/cms.yml
@@ -6,12 +6,8 @@
   pause:
     seconds: 30
 
-# Prepare CMS template
-- name: Prepare CMS template
-  template:
-    src: "cms_base.j2"
-    dest: "{{ tmp_dir }}/cms_base.json"
-  delegate_to: localhost
+- set_fact:
+    cms_config_json: "{{ lookup('template', 'cms_base.j2', convert_data=False) }}"
 
 # https://cloudera.github.io/cm_api/apidocs/v12/path__cm_service.html#PUT
 - name: Setup the Cloudera Management Services (CMS)
@@ -19,7 +15,7 @@
     url: "{{ cm_api_url }}/cm/service"
     method: PUT
     body_format: json
-    body: "{{ lookup('file', ''+ tmp_dir + '/cms_base.json') }}"
+    body: "{{ cms_config_json|to_json }}"
     status_code: 200,400
     force_basic_auth: yes
     user: "{{ scm_default_user }}"
@@ -29,7 +25,6 @@
   failed_when:
     - "'MGMT' not in cms_resp.content"
     - "'CMS instance already exists' not in cms_resp.content"
-  delegate_to: localhost
 
 - debug:
     var: cms_resp

--- a/roles/scm/tasks/cms.yml
+++ b/roles/scm/tasks/cms.yml
@@ -26,7 +26,7 @@
     - "'MGMT' not in cms_resp.content"
     - "'CMS instance already exists' not in cms_resp.content"
 
-- debug:
+- debug: 
     var: cms_resp
     verbosity: 1
 
@@ -43,6 +43,6 @@
   register: start_resp
   failed_when: "'startTime' not in start_resp.content"
 
-- debug:
+- debug: 
     var: start_resp
     verbosity: 1


### PR DESCRIPTION
Howto run:
```
# ps: ansible >2.8.2 works fine also (but not 2.9.0, see the README)
pip2 install ansible==2.9.1 
pip2 install molecule==2.22

# simple cmd
cd <repo base folder>
molecule test

# the same, but avoid the 'destroy' (if something fails for ex.):
molecule test --destroy=never --scenario-name default
```

Early version Notes:
* the whole playbook runs through
  * but the CM 'template import' action is still running (on my 1. full try, not sure if my 16GB Macbook has enough memory/resources for this config to complete)
* to run as non root/sudo user, I had todo a small patch (see below), I will create a separate PR for that
* Test inspired by similar molecule config I did for HDP deployments in https://github.com/hortonworks/ansible-hortonworks/pull/175

TODOs
* [ ] travis build
  * [ ] try with suited small CDH host_templates (that allow a CDH cluster install with the 7.5GB VM memory limit of travis, free tier)
* [ ] more tests
* [ ] multi nodes installs
* [ ] test matrix for various versions, DBs , etc
